### PR TITLE
Add Support for index.juvix.md and README.juvix.md as Homepage

### DIFF
--- a/mkdocs_juvix/plugin.py
+++ b/mkdocs_juvix/plugin.py
@@ -93,18 +93,10 @@ class JuvixPlugin(BasePlugin):
             page.file.abs_dest_path = page.file.abs_dest_path.replace(
                 text, "")
 
-        if page.file.name.endswith(index):
+        if page.file.name == index:
             path_change(index)
-        elif page.file.name.endswith(readme):
+        elif page.file.name == readme:
             path_change(readme)
         elif page.file.name.endswith(juvix):
             path_change(juvix)
         return markdown
-
-    def on_nav(self, nav: Navigation, config: Config, files: Files):
-
-        for page in nav.pages:
-           if page.file.src_path.endswith("index.juvix.md"):
-            nav.homepage = page
-        return nav
-

--- a/mkdocs_juvix/plugin.py
+++ b/mkdocs_juvix/plugin.py
@@ -82,10 +82,26 @@ class JuvixPlugin(BasePlugin):
         return page.content
 
     def on_page_markdown(self, markdown, page, config, files: Files):
-        if page.file.name.endswith(".juvix"):
-            page.file.name = page.file.name.replace(".juvix", "")
-            page.file.url = page.file.url.replace(".juvix", "")
-            page.file.dest_uri = page.file.dest_uri.replace(".juvix", "")
+        index = "index.juvix"
+        juvix = ".juvix"
+
+        def path_change(text):
+            page.file.name = page.file.name.replace(text, "")
+            page.file.url = page.file.url.replace(text, "")
+            page.file.dest_uri = page.file.dest_uri.replace(text, "")
             page.file.abs_dest_path = page.file.abs_dest_path.replace(
-                ".juvix", "")
+                text, "")
+
+        if page.file.name.endswith(index):
+            path_change(index)
+        elif page.file.name.endswith(juvix):
+            path_change(juvix)
         return markdown
+
+    def on_nav(self, nav: Navigation, config: Config, files: Files):
+
+        for page in nav.pages:
+           if page.file.src_path.endswith("index.juvix.md"):
+            nav.homepage = page
+        return nav
+

--- a/mkdocs_juvix/plugin.py
+++ b/mkdocs_juvix/plugin.py
@@ -83,6 +83,7 @@ class JuvixPlugin(BasePlugin):
 
     def on_page_markdown(self, markdown, page, config, files: Files):
         index = "index.juvix"
+        readme = "README.juvix"
         juvix = ".juvix"
 
         def path_change(text):
@@ -94,6 +95,8 @@ class JuvixPlugin(BasePlugin):
 
         if page.file.name.endswith(index):
             path_change(index)
+        elif page.file.name.endswith(readme):
+            path_change(readme)
         elif page.file.name.endswith(juvix):
             path_change(juvix)
         return markdown


### PR DESCRIPTION
This PR closes:
- https://github.com/anoma/juvix-mkdocs/issues/2

It updates the plugin file to include `on_nav` function which sets `index.juvix.md` file as homepage in navigation if detected and chnages `on_page_markdown` to reference any such files without `/index/` reference when building.

In practical terms, sets `index.juvix.md` file as the homepage when detected.